### PR TITLE
Fix rounding in parse_music_file

### DIFF
--- a/music_file_parser.py
+++ b/music_file_parser.py
@@ -75,15 +75,16 @@ def parse_music_file(file_path, manual_tempo=None):
             start = time_points[i]
             end = time_points[i + 1]
             dur = end - start
-            if dur <= 0:
+            rounded = round(dur, 3)
+            if rounded <= 0:
                 continue
 
             active = {e[0] for e in events if e[1] < end and e[2] > start}
             if active:
                 chord_str = "+".join(sorted(active))
-                song_notes.append(f"{chord_str}:{dur:.3f}")
+                song_notes.append(f"{chord_str}:{rounded:.3f}")
             else:
-                song_notes.append(f"R:{dur:.3f}")
+                song_notes.append(f"R:{rounded:.3f}")
 
         print("✅ Processing complete!")
         print(f"   Notes generated: {len(song_notes)}")


### PR DESCRIPTION
## Summary
- ensure parse_music_file rounds durations before use
- skip entries where the rounded duration is zero

## Testing
- `python -m py_compile music_file_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_687ba85d30a0832996bcbc3324d2d07d